### PR TITLE
Add NovaAI integration example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ POSTGRES_URL=****
 # Instructions to create a Redis store here:
 # https://vercel.com/docs/redis
 REDIS_URL=****
+
+# NovaAI configuration
+NOVA_AI_API_KEY=****
+NOVA_AI_API_URL=https://api.novaai.example.com/generate

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   - Unified API for generating text, structured objects, and tool calls with LLMs
   - Hooks for building dynamic chat and generative user interfaces
   - Supports xAI (default), OpenAI, Fireworks, and other model providers
+  - Example NovaAI integration via the `generateSlogan` tool
 - [shadcn/ui](https://ui.shadcn.com)
   - Styling with [Tailwind CSS](https://tailwindcss.com)
   - Component primitives from [Radix UI](https://radix-ui.com) for accessibility and flexibility
@@ -36,7 +37,7 @@
 
 ## Model Providers
 
-This template ships with [xAI](https://x.ai) `grok-2-1212` as the default chat model. However, with the [AI SDK](https://sdk.vercel.ai/docs), you can switch LLM providers to [OpenAI](https://openai.com), [Anthropic](https://anthropic.com), [Cohere](https://cohere.com/), and [many more](https://sdk.vercel.ai/providers/ai-sdk-providers) with just a few lines of code.
+This template ships with [xAI](https://x.ai) `grok-2-1212` as the default chat model. However, with the [AI SDK](https://sdk.vercel.ai/docs), you can switch LLM providers to [OpenAI](https://openai.com), [Anthropic](https://anthropic.com), [Cohere](https://cohere.com/), and [many more](https://sdk.vercel.ai/providers/ai-sdk-providers) with just a few lines of code. You can even configure Publicityvisual's NovaAI by setting `NOVA_AI_API_KEY` and `NOVA_AI_API_URL`.
 
 ## Deploy Your Own
 

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -23,6 +23,7 @@ import { createDocument } from '@/lib/ai/tools/create-document';
 import { updateDocument } from '@/lib/ai/tools/update-document';
 import { requestSuggestions } from '@/lib/ai/tools/request-suggestions';
 import { getWeather } from '@/lib/ai/tools/get-weather';
+import { generateSlogan } from '@/lib/ai/tools/generate-slogan';
 import { isProductionEnvironment } from '@/lib/constants';
 import { myProvider } from '@/lib/ai/providers';
 import { entitlementsByUserType } from '@/lib/ai/entitlements';
@@ -156,6 +157,7 @@ export async function POST(request: Request) {
               ? []
               : [
                   'getWeather',
+                  'generateSlogan',
                   'createDocument',
                   'updateDocument',
                   'requestSuggestions',
@@ -164,6 +166,7 @@ export async function POST(request: Request) {
           experimental_generateMessageId: generateUUID,
           tools: {
             getWeather,
+            generateSlogan,
             createDocument: createDocument({ session, dataStream }),
             updateDocument: updateDocument({ session, dataStream }),
             requestSuggestions: requestSuggestions({

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -164,7 +164,7 @@ const PurePreviewMessage = ({
                     <div
                       key={toolCallId}
                       className={cx({
-                        skeleton: ['getWeather'].includes(toolName),
+                        skeleton: ['getWeather', 'generateSlogan'].includes(toolName),
                       })}
                     >
                       {toolName === 'getWeather' ? (

--- a/lib/ai/tools/generate-slogan.ts
+++ b/lib/ai/tools/generate-slogan.ts
@@ -1,0 +1,29 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+
+export const generateSlogan = tool({
+  description: 'Generate a creative marketing slogan using NovaAI',
+  parameters: z.object({
+    prompt: z.string(),
+  }),
+  execute: async ({ prompt }) => {
+    const apiUrl = process.env.NOVA_AI_API_URL;
+    const apiKey = process.env.NOVA_AI_API_KEY;
+
+    if (!apiUrl || !apiKey) {
+      throw new Error('NovaAI is not configured');
+    }
+
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ prompt }),
+    });
+
+    const data = await response.json();
+    return data;
+  },
+});


### PR DESCRIPTION
## Summary
- integrate a new NovaAI tool `generateSlogan`
- register the new tool in the chat API route
- show skeleton for `generateSlogan`
- document NovaAI environment variables and usage

## Testing
- `pnpm test` *(fails: 34 tests did not run and HTML report served)*

------
https://chatgpt.com/codex/tasks/task_b_6844d7c2cb9083318c66fabbd2ee7fda